### PR TITLE
Fix GridBuffer Destructor

### DIFF
--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -86,6 +86,8 @@ namespace PMacc
 
         virtual ~DeviceBufferIntern()
         {
+            __startOperation(ITask::TASK_CUDA);
+
             if (sizeOnDevice)
             {
                 CUDA_CHECK(cudaFree(sizeOnDevicePtr));

--- a/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/HostBufferIntern.hpp
@@ -68,6 +68,8 @@ public:
      */
     virtual ~HostBufferIntern() throw (std::runtime_error)
     {
+        __startOperation(ITask::TASK_HOST);
+
         if (pointer && ownPointer)
         {
             CUDA_CHECK(cudaFreeHost(pointer));

--- a/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/MappedBufferIntern.hpp
@@ -60,6 +60,9 @@ public:
      */
     virtual ~MappedBufferIntern() throw (std::runtime_error)
     {
+        __startOperation(ITask::TASK_CUDA);
+        __startOperation(ITask::TASK_HOST);
+
         if (pointer && ownPointer)
         {
             CUDA_CHECK(cudaFreeHost(pointer));


### PR DESCRIPTION
In case the GridBuffer is not running for the whole simulation, we have to make sure that the transaction dependencies between the allocated memory (host, device, mapped) and the GridBuffer will be sheduled right.

Fixes the problem reported during the development of https://github.com/ComputationalRadiationPhysics/picongpu/pull/169 .
