### PR TITLE
multi warps and shared mem optimization

### DIFF
--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -41,6 +41,8 @@
 #include <pmacc/memory/CtxArray.hpp>
 #include <pmacc/particles/frame_types.hpp>
 
+#define PICONGPU_NUMWARPS 2
+
 namespace picongpu
 {
 
@@ -108,7 +110,7 @@ struct KernelComputeCurrent
          * Each virtual CUDA block is working on a frame, if we have 2 blocks each block processes
          * every second frame until all frames are processed.
          */
-        constexpr uint32_t numVirtualBlocks = 1; //( numWorkers + numParticlesPerFrame - 1u ) / numParticlesPerFrame;
+        constexpr uint32_t numVirtualBlocks = PICONGPU_NUMWARPS; //( numWorkers + numParticlesPerFrame - 1u ) / numParticlesPerFrame;
 
 
         const DataSpace< simDim > block(
@@ -119,7 +121,7 @@ struct KernelComputeCurrent
         uint32_t const workerIdx = threadIdx.x;
 
         using VirtualWorkerDomCfg = IdxConfig<
-            32, //numParticlesPerFrame * numVirtualBlocks,
+            32 * numVirtualBlocks, //numParticlesPerFrame * numVirtualBlocks,
             numWorkers
         >;
 
@@ -135,11 +137,11 @@ struct KernelComputeCurrent
                 uint32_t const
             )
             {
-                return linearIdx / numParticlesPerFrame;
+                return linearIdx / 32;
             }
         );
 
-#if 0
+
         /* linear virtual worker index in the virtual block*/
         memory::CtxArray<
             uint32_t,
@@ -153,10 +155,10 @@ struct KernelComputeCurrent
             )
             {
                 /* map virtualLinearIdCtx to the range [0;numParticlesPerFrame) */
-                return linearIdx - ( virtualBlockIdCtx[ idx ] * numParticlesPerFrame );
+                return linearIdx - ( virtualBlockIdCtx[ idx ] * 32 );
             }
         );
-#endif
+
         /* each virtual worker stores the currently used frame */
         memory::CtxArray<
             FramePtr,
@@ -178,23 +180,16 @@ struct KernelComputeCurrent
             )
             {
                 frameCtx[ idx ] = boxPar.getLastFrame( block );
-                if( frameCtx[ idx ].isValid() && virtualBlockIdCtx[ idx ] == 0u )
+                if( frameCtx[ idx ].isValid() )
                     particlesInSuperCellCtx[ idx ] = boxPar.getSuperCell( block ).getSizeLastFrame();
-
-                /* select N-th (N=virtualBlockId) frame from the end of the list */
-                for( uint32_t i = 1; i <= virtualBlockIdCtx[ idx ] && frameCtx[ idx ].isValid(); ++i )
-                {
-                    particlesInSuperCellCtx[ idx ] = numParticlesPerFrame;
-                    frameCtx[ idx ] = boxPar.getPreviousFrame( frameCtx[ idx ] );
-                }
             }
         );
 
         using MatDesc = SuperCellDescription<
-            typename pmacc::math::CT::make_Int<
-                DIM2,
-                16
-            >::type
+            pmacc::math::CT::Int<
+                16,
+                16 * numVirtualBlocks
+            >
         >;
 
         /* this memory is used by all virtual blocks */
@@ -281,12 +276,15 @@ struct KernelComputeCurrent
                     /** particle 0 -> thread 0-15
                      *  particle 1 -> thread 16-31
                      */
-                    int const parOffset = linearIdx / 16;
-                    // round up to the next multiple of two
-                    int const parInSuperCell = ( ( particlesInSuperCellCtx[ idx ] + 1 ) / 2 ) * 2;
-                    for( int i = parOffset; i < parInSuperCell; i += 2 )
-                    {
+                    int const parOffset = virtualLinearIdCtx[ idx ] / 16;
 
+                    constexpr int numActiveParticles = 2 * numVirtualBlocks;
+                    // round up to the next multiple of numActiveParticles
+                    int const parInSuperCell = ( ( particlesInSuperCellCtx[ idx ] + numActiveParticles - 1 ) / numActiveParticles ) * numActiveParticles;
+                    for( int i = parOffset + 2 * virtualBlockIdCtx[ idx ]; i < parInSuperCell; i += numActiveParticles )
+                    {
+                        __syncthreads();
+                        // this collective calls are the reason why we need to move with all threads throw this loop
                         collectiveSetMatZero( acc, setMatZero, matA );
                         collectiveSetMatZero( acc, setMatZero, matB );
                         // the result matrix will be set to zero in the matrix multiplication operation
@@ -305,10 +303,10 @@ struct KernelComputeCurrent
                                 *frameCtx[ idx ],
                                 i,
                                 cachedJ,
-                                matA,
-                                matB,
-                                matResult,
-                                linearIdx,
+                                matA.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),
+                                matB.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),
+                                matResult.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),
+                                virtualLinearIdCtx[ idx ],
                                 i < particlesInSuperCellCtx[ idx ]
                             );
                         }
@@ -324,11 +322,8 @@ struct KernelComputeCurrent
                 {
                     if( frameCtx[ idx ].isValid() )
                     {
+                        frameCtx[ idx ] = boxPar.getPreviousFrame( frameCtx[ idx ] );
                         particlesInSuperCellCtx[ idx ] = numParticlesPerFrame;
-                        for( int i = 0; i < numVirtualBlocks && frameCtx[ idx ].isValid(); ++i )
-                        {
-                            frameCtx[ idx ] = boxPar.getPreviousFrame( frameCtx[ idx ] );
-                        }
                     }
                 }
             );
@@ -377,9 +372,9 @@ struct ComputeCurrentPerFrame
         FrameType& frame,
         const int parId,
         BoxJ & jBox,
-        T_MatA & matA,
-        T_MatB & matB,
-        T_MatR & matResult,
+        T_MatA matA,
+        T_MatB matB,
+        T_MatR matResult,
         const int localIdx,
         const bool parIsValid
     )

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -201,7 +201,7 @@ struct KernelComputeCurrent
             MatDesc()
         );
 
-                /* this memory is used by all virtual blocks */
+        /* this memory is used by all virtual blocks */
         auto matB = CachedBox::create<
             2u,
             half
@@ -210,7 +210,11 @@ struct KernelComputeCurrent
             MatDesc()
         );
 
-        /* this memory is used by all virtual blocks */
+        /* this memory is used by all virtual blocks
+         * It is useful to have a result matrix. Else we need to write the results
+         * to matrix A or B what means we need to set is after each particle back to zero.
+         * This step can be skipped if we have this matrix with results.
+         */
         auto matResult = CachedBox::create<
             3u,
             float
@@ -249,6 +253,12 @@ struct KernelComputeCurrent
         /* initialize shared memory with zeros */
         collectiveSet( acc, set, cachedJ );
 
+        /* we need only set the matrix one to zero because all particle values will always
+         * set to an valid value
+         */
+        collectiveSetMatZero( acc, setMatZero, matA );
+        collectiveSetMatZero( acc, setMatZero, matB );
+
         __syncthreads();
 
         while( true )
@@ -280,17 +290,9 @@ struct KernelComputeCurrent
 
                     constexpr int numActiveParticles = 2 * numVirtualBlocks;
                     // round up to the next multiple of numActiveParticles
-                    int const parInSuperCell = ( ( particlesInSuperCellCtx[ idx ] + numActiveParticles - 1 ) / numActiveParticles ) * numActiveParticles;
+                    int const parInSuperCell = ( ( particlesInSuperCellCtx[ idx ] + 1 ) / 2 ) * 2;
                     for( int i = parOffset + 2 * virtualBlockIdCtx[ idx ]; i < parInSuperCell; i += numActiveParticles )
                     {
-                        __syncthreads();
-                        // this collective calls are the reason why we need to move with all threads throw this loop
-                        collectiveSetMatZero( acc, setMatZero, matA );
-                        collectiveSetMatZero( acc, setMatZero, matB );
-                        // the result matrix will be set to zero in the matrix multiplication operation
-                        // collectiveSetMatZero( acc, setMatZero, matResult );
-
-                        __syncthreads();
                         /* this test is only important for the last frame
                          * if the frame is not the last one then: `particlesInSuperCell == numParticlesPerFrame`
                          */
@@ -303,6 +305,7 @@ struct KernelComputeCurrent
                                 *frameCtx[ idx ],
                                 i,
                                 cachedJ,
+                                // shift to the data for the warp
                                 matA.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),
                                 matB.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),
                                 matResult.shift( DataSpace< DIM2 >( 0, 16 * virtualBlockIdCtx[ idx ] ) ),

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -263,9 +263,8 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
     /* tuning parameter to use more workers than cells in a supercell
      * valid domain: 1 <= workerMultiplier
      */
-#if 0
-    const int workerMultiplier = 2;
-#endif
+    const int workerMultiplier = PICONGPU_NUMWARPS;
+
     using FrameType = typename ParticlesClass::FrameType;
     typedef typename pmacc::traits::Resolve<
         typename GetFlagType<FrameType, current<> >::type
@@ -306,7 +305,7 @@ void FieldJ::computeCurrent( ParticlesClass &parClass, uint32_t )
     FrameSolver solver( DELTA_T );
 
     constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
-        32//pmacc::math::CT::volume< SuperCellSize >::type::value * workerMultiplier
+        32 * workerMultiplier
     >::value;
 
     do

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -395,7 +395,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
                          */
                         jOffset[ w ] = k;
                         accumulated_J += DS( parLine, k, w ) * tmp;
-                        batchCursorJ( jOffset )[ w ] += accumulated_J;
+                        atomicAdd(&(batchCursorJ( jOffset )[ w ]), accumulated_J, ::alpaka::hierarchy::Threads{});
                     }
                 }
 
@@ -413,7 +413,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
                          */
                         accumulated_J += DS( parLine, k, 0 ) * tmp;
                         jOffset.x() = k;
-                        batchCursorJ( jOffset ).x() += accumulated_J;
+                        atomicAdd(&(batchCursorJ( jOffset ).x()), accumulated_J, ::alpaka::hierarchy::Threads{});
                     }
                 }
             }

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -172,24 +172,6 @@ struct Esirkepov<T_ParticleShape, DIM3>
         nvcuda::wmma::store_matrix_sync(matResult.getPointer() , acc_frag, 16, nvcuda::wmma::mem_row_major);
     }
 
-    template< typename Mat>
-    HDINLINE void pMat(Mat const & matA)
-    {
-        constexpr int matSize = 16;
-
-
-        for( int k = 0; k < matSize; k++)
-        {
-            for( int i = 0; i < matSize; i++ )
-            {
-                printf("%f ",matA( DataSpace< DIM2>( i, k ) ));
-            }
-            printf("\n");
-        }
-        printf("-----\n");
-
-    }
-
     /**
      * deposites current in z-direction
      *
@@ -240,6 +222,9 @@ struct Esirkepov<T_ParticleShape, DIM3>
         int const batch = tid / 16;
         int const matRow = idx % 4;
         int const i = begin + matRow;
+
+        // wait that previous round is flushed to the charge current matrix in the shared memory
+        __syncwarp();
 
 
         if( parIsValid && idx < 12 )
@@ -294,31 +279,10 @@ struct Esirkepov<T_ParticleShape, DIM3>
         }
 
         // wait that matrix is filled
-        __syncthreads();
+        __syncwarp();
 
+        // this function is also syncing the warp
         matmul( matA, matB, matResult, tid );
-#if 0
-        if(blockIdx.x == 0 && blockIdx.y == 0 &&blockIdx.z == 0 &&threadIdx.x == 0 &&threadIdx.y == 0 &&threadIdx.z == 0)
-        {
-            printf("A:\n");
-            pMat(matA);
-            printf("B:\n");
-            pMat(matB);
-        }
-
-        matmul( matA, matB, matResult, tid );
-
-        __syncthreads();
-
-        if(blockIdx.x == 0 && blockIdx.y == 0 &&blockIdx.z == 0 &&threadIdx.x == 0 &&threadIdx.y == 0 &&threadIdx.z == 0)
-        {
-            printf("C:\n");
-            pMat(matResult);
-        }
-#endif
-
-        // wait that the matrix is calculated
-        __syncthreads();
 
         // idx is between [0;16)
         DataSpace< DIM2 > id2d( idx % 4 , idx / 4 );
@@ -418,8 +382,6 @@ struct Esirkepov<T_ParticleShape, DIM3>
                 }
             }
         }
-
-       __syncthreads();
     }
 
     /** calculate S0 (see paper)


### PR DESCRIPTION
- add PICONGPU_NUMWARPS to configure the number of warps for the current deposition
- refactore `FieldJ.kernel` to support multiple warps
- set shared memory for matrix A and B only once per  kernel to zero
- use `__syncwarp` instead of `__syncthreads`