### PR TITLE
enforce shared memory atomic adds

### DIFF
--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -106,6 +106,11 @@ struct KernelComputeCurrent
         constexpr uint32_t numParticlesPerFrame = pmacc::math::CT::volume< SuperCellSize >::type::value;
         constexpr uint32_t numWorkers = T_numWorkers;
 
+        PMACC_CASSERT_MSG(
+            __PICONGPU_NUMWARPS_is_to_large_for_the_supercell,
+            numParticlesPerFrame >= PICONGPU_NUMWARPS * 32
+        );
+
         /* We work with virtual CUDA blocks if we have more workers than particles.
          * Each virtual CUDA block is working on a frame, if we have 2 blocks each block processes
          * every second frame until all frames are processed.


### PR DESCRIPTION
- add option PIC_ENFORCE_SHARED_ATOMICS to `Esirkepov.hpp`
- add assert to be shure that supercell size fits number of warps