### PR TITLE
add emulated mma

### DIFF
--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -41,8 +41,6 @@
 #include <pmacc/memory/CtxArray.hpp>
 #include <pmacc/particles/frame_types.hpp>
 
-#define PICONGPU_NUMWARPS 2
-
 namespace picongpu
 {
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -34,6 +34,7 @@
 
 #include <mma.h>
 
+#define PICONGPU_NUMWARPS 1
 #define PIC_ENFORCE_SHARED_ATOMICS 1
 #define PIC_USE_MMA 1
 
@@ -159,7 +160,7 @@ struct Esirkepov<T_ParticleShape, DIM3>
 #else
         PMACC_CASSERT_MSG(
             __PICONGPU_NUMWARPS_must_be_one_if_non_mma_are_used,
-            numParticlesPerFrame == 1
+            PICONGPU_NUMWARPS == 1
         );
         __syncwarp();
         constexpr int matSize = 16;

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -145,16 +145,20 @@ struct FreeMemory
         if (ptr != nullptr)
         {
 #if( PMACC_CUDA_ENABLED == 1 )
-            auto rc = cudaFreeHost(ptr);
-            /* cupla can't handle foreign memory allocated with `cudaHostAlloc`
-             * therefore the cupla error `cuplaErrorMemoryAllocation` is ignored
-             */
-            if(rc != cuplaErrorMemoryAllocation)
-                CUDA_CHECK(rc)
+/* cupla is not supporting the function cudaHostAlloc to create mapped memory.
+ * Therefore we need to call the native CUDA function cudaFreeHost to free the memory.
+ * Due to the renaming of cuda functions with cupla via macros we need to remove
+ * the renaming to get access to the native cuda function.
+ * @todo this is a workaround plese fix me. We need to investigate if
+ * it is possible to have mapped/unified memory in alpaka.
+ */
+#   undef cudaFreeHost
+            CUDA_CHECK((cuplaError_t)cudaFreeHost(ptr));
+// re-introduce the cupla macro
+#   define cudaFreeHost(...) cuplaFreeHost(__VA_ARGS__)
 #else
             __deleteArray(ptr);
 #endif
-            ptr=nullptr;
         }
     }
 };

--- a/include/pmacc/memory/buffers/MappedBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/MappedBufferIntern.hpp
@@ -55,7 +55,11 @@ public:
     DeviceBuffer<TYPE, DIM>(size, size),
     pointer(nullptr), ownPointer(true)
     {
-        CUDA_CHECK(cudaMallocHost(&pointer, size.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
+#if( PMACC_CUDA_ENABLED == 1 )
+        CUDA_CHECK((cuplaError_t)cudaHostAlloc(&pointer, size.productOfComponents() * sizeof (TYPE), cudaHostAllocMapped));
+#else
+        pointer = new TYPE[size.productOfComponents()];
+#endif
         reset(false);
     }
 
@@ -69,7 +73,21 @@ public:
 
         if (pointer && ownPointer)
         {
-            CUDA_CHECK(cudaFreeHost(pointer));
+#if( PMACC_CUDA_ENABLED == 1 )
+/* cupla is not supporting the function cudaHostAlloc to create mapped memory.
+ * Therefore we need to call the native CUDA function cudaFreeHost to free the memory.
+ * Due to the renaming of cuda functions with cupla via macros we need to remove
+ * the renaming to get access to the native cuda function.
+ * @todo this is a workaround plese fix me. We need to investigate if
+ * it is possible to have mapped/unified memory in alpaka.
+ */
+#   undef cudaFreeHost
+            CUDA_CHECK((cuplaError_t)cudaFreeHost(pointer));
+// re-introduce the cupla macro
+#   define cudaFreeHost(...) cuplaFreeHost(__VA_ARGS__)
+#else
+            __deleteArray(pointer);
+#endif
         }
     }
 


### PR DESCRIPTION
- allow to use emulated mma with one warp per block
- add assert to avoid that more tahn one warp is used if mma is emulated
- move define `PICONGPU_NUMWARPS` from `FieldJ.kernel` to `Esirkepov`