### PR TITLE
alpaka/SysInfo: Backport cpuid Fix from SPEC

### DIFF
--- a/thirdParty/alpaka/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/thirdParty/alpaka/include/alpaka/dev/cpu/SysInfo.hpp
@@ -58,7 +58,7 @@ namespace alpaka
         {
             namespace detail
             {
-#if BOOST_ARCH_X86
+#if !defined(SPEC) && defined(BOOST_ARCH_X86)
     #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && defined(__INTEL_COMPILER))
         #include <cpuid.h>
                 //-----------------------------------------------------------------------------
@@ -83,7 +83,7 @@ namespace alpaka
                 inline auto getCpuName()
                 -> std::string
                 {
-#if BOOST_ARCH_X86
+#if !defined(SPEC) && defined(BOOST_ARCH_X86)
                     // Get extended ids.
                     std::uint32_t ex[4] = {0};
                     cpuid(0x80000000, 0, ex);


### PR DESCRIPTION
Do not call cpuid in SPEC: does not work With PGI Compiler

Maybe this could be replaced by a check for PGI, or better a whitelist for compilers for which this is known to work e.g. gcc and go upstream to Alpaka.