### PR TITLE
fix memory scaling of exchnages

### DIFF
--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -90,7 +90,7 @@ Particles<
      * we can avoid performance decreases due to double send of particles.
      */
     double numBaseCells = 128.0 * 128.0 * 128.0;
-    double numGlobalCells = Environment<simDim>::get().SubGrid().getGlobalDomain().size.productOfComponents();
+    double numGlobalCells = Environment<simDim>::get().SubGrid().getLocalDomain().size.productOfComponents();
     size_t memScalingFactorZ = static_cast< size_t >( std::ceil( numGlobalCells / numBaseCells / 2.0 ) );
     size_t memScalingFactorOther = static_cast< size_t >( std::ceil( numGlobalCells / numBaseCells / 4.0 ) );
 

--- a/include/picongpu/simulationControl/MySimulation.hpp
+++ b/include/picongpu/simulationControl/MySimulation.hpp
@@ -306,6 +306,8 @@ public:
         auto fieldJ = new FieldJ( *cellDescription );
         dc.share( std::shared_ptr< ISimulationData >( fieldJ ) );
 
+//fieldTmp is not required for SPEC benchmarks.
+#if !defined(SPEC)
         std::vector< FieldTmp * > fieldTmp;
         for( uint32_t slot = 0; slot < fieldTmpNumSlots; ++slot)
         {
@@ -313,6 +315,7 @@ public:
             fieldTmp.push_back( newFld );
             dc.share( std::shared_ptr< ISimulationData >( newFld ) );
         }
+#endif
         pushBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER + GUARD > (*cellDescription);
         currentBGField = new cellwiseOperation::CellwiseOperation < CORE + BORDER > (*cellDescription);
 
@@ -330,7 +333,7 @@ public:
  * To keep the initialization enabled would result into a longer initialization than the
  * benchmark itself on GPUs.
  */
-#if 0
+#if !defined(SPEC)
         // create factory for the random number generator
         const uint32_t userSeed = random::seed::ISeed< random::SeedGenerator >{}();
         const uint32_t seed = std::hash<std::string>{}(


### PR DESCRIPTION
fix species exchange memory auto scaling: Use the local domain size instead of the global size to scale the exchange memory for species

disable FielTmp memory allocation: Since FieldTmp is for SPEC not needed we can disable the creation and save some memory.