### PR TITLE
Add radiation to spec benchmark

### DIFF
--- a/etc/picongpu/1_radiation.cfg
+++ b/etc/picongpu/1_radiation.cfg
@@ -1,0 +1,77 @@
+# Copyright 2013-2021 Rene Widera, Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="02:00:00"
+
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
+
+TBG_gridSize="128 128 128"
+TBG_steps="10"
+
+TBG_periodic="--periodic 1 1 1"
+
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+TBG_radiation="--e_radiation.period 1 --e_radiation.dump 5 \
+               --e_radiation.totalRadiation \
+               --e_radiation.lastRadiation "
+
+TBG_plugins=" !TBG_radiation \
+               --p_macroParticlesCount.period 100          \
+              --e_macroParticlesCount.period 100          \
+              --fields_energy.period 100                  \
+              --e_energy.period 100 --e_energy.filter all \
+              --p_energy.period 100 --p_energy.filter all"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/benchmarks/SPEC/cmakeFlags
+++ b/share/picongpu/benchmarks/SPEC/cmakeFlags
@@ -32,6 +32,16 @@
 flags[0]=""
 flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC'"
 flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision64Bit;-DPARAM_PARTICLESHAPE=TSC'"
+# common radiation with ideal setup
+flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC;-DPARAM_RADIATION=1'"
+# common radiation with non-ideal form factor but ideal window function
+flags[4]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC;-DPARAM_RADIATION=1;-DPARAM_RADFORMFACTOR=radFormFactor_coherent'"
+# common radiation with ideal form factor but non-ideal window function
+flags[5]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC;-DPARAM_RADIATION=1;-DPARAM_RADWINDOWFUNCTION=radWindowFunctionNone'"
+# common radiation with both non-ideal form factor and window function
+flags[6]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC;-DPARAM_RADIATION=1;-DPARAM_RADFORMFACTOR=radFormFactor_coherent;-DPARAM_RADWINDOWFUNCTION=radWindowFunctionNone'"
+
+
 
 ################################################################################
 # execution

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
@@ -1,0 +1,205 @@
+/* Copyright 2013-2021 Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#ifndef PARAM_RADFORMFACTOR
+#    define PARAM_RADFORMFACTOR radFormFactor_Gauss_spherical
+#endif
+
+#ifndef PARAM_RADWINDOWFUNCTION
+#    define PARAM_RADWINDOWFUNCTION radWindowFunctionTriplett
+#endif
+
+
+/*
+  radiation verbose level:
+  0=nothing, 1=physics, 2=simulation_state, 4=memory, 8=critical
+*/
+
+#define PIC_VERBOSE_RADIATION 3
+
+#include "picongpu/algorithms/Gamma.def"
+#include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/plugins/radiation/VectorTypes.hpp"
+#include "picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
+
+namespace picongpu
+{
+    namespace plugins
+    {
+        namespace radiation
+        {
+            namespace linear_frequencies
+            {
+                namespace SI
+                {
+                    constexpr float_64 omega_min = 0.0;
+                    constexpr float_64 omega_max = 1.06e16;
+                } // namespace SI
+
+                constexpr unsigned int N_omega = 1024; // number of frequencies
+            } // namespace linear_frequencies
+
+            namespace log_frequencies
+            {
+                namespace SI
+                {
+                    // plasma omega = sqrt( (electron density * (1.6e-19)^2) / (8.854e-12 * 9.11e-31) )
+                    //              = 1.78e14 1/s
+                    constexpr float_64 omega_pe = 1.78e14;
+                    constexpr float_64 omega_min = 0.1 * omega_pe;
+                    constexpr float_64 omega_max = 200 * omega_pe;
+                } // namespace SI
+
+                constexpr unsigned int N_omega = 256; // number of frequencies
+            } // namespace log_frequencies
+
+
+            namespace frequencies_from_list
+            {
+                /** path to text file with frequencies */
+                constexpr const char* listLocation = "/path/to/frequency.list";
+                constexpr unsigned int N_omega = 2048; // number of frequencies
+            } // namespace frequencies_from_list
+
+
+            namespace radiation_frequencies = log_frequencies;
+
+
+            namespace radiationNyquist
+            {
+                constexpr float_32 NyquistFactor = 0.5;
+            }
+
+            ///////////////////////////////////////////////////
+
+
+            // correct treatment of coherent and incoherent  radiation from macroparticles
+            /* Choose different form factors in order to consider different  particle shapes for radiation
+             *  - radFormFactor_CIC_3D ... CIC charge distribution
+             *  - radFormFactor_TSC_3D ... TSC charge distribution
+             *  - radFormFactor_PCS_3D ... PCS charge distribution
+             *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
+             *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+             *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
+             *  - radFormFactor_incoherent ... only incoherent radiation
+             *  - radFormFactor_coherent ... only coherent radiation
+             */
+            namespace radFormFactor_CIC_3D
+            {
+            }
+            namespace radFormFactor_TSC_3D
+            {
+            }
+            namespace radFormFactor_PCS_3D
+            {
+            }
+            namespace radFormFactor_CIC_1Dy
+            {
+            }
+            namespace radFormFactor_Gauss_spherical
+            {
+            }
+            namespace radFormFactor_Gauss_cell
+            {
+            }
+            namespace radFormFactor_incoherent
+            {
+            }
+            namespace radFormFactor_coherent
+            {
+            }
+
+
+            namespace radFormFactor = PARAM_RADFORMFACTOR;
+
+
+            ///////////////////////////////////////////////////////////
+
+
+            namespace parameters
+            {
+                constexpr unsigned int N_observer = 16; // number of looking directions
+
+            } /* end namespace parameters */
+
+            /** activate particles for radiation */
+            struct GammaFilterFunctor
+            {
+                static constexpr float_X radiationGamma = 5.0;
+
+                template<typename T_Particle>
+                HDINLINE void operator()(T_Particle& particle)
+                {
+                    if(picongpu::gamma<float_X>(
+                           particle[picongpu::momentum_],
+                           picongpu::traits::attribute::getMass(particle[picongpu::weighting_], particle))
+                       >= radiationGamma)
+                        particle[picongpu::radiationMask_] = true;
+                }
+            };
+
+
+            /* filter to enable radiation for electrons
+             *
+             * to enable the filter:
+             *   - goto file `speciesDefinition.param`
+             *   - add the attribute `radiationMask` to the electron species
+             */
+            using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<GammaFilterFunctor>;
+
+
+            //////////////////////////////////////////////////
+
+
+            // add a window function weighting to the radiation in order
+            // to avoid ringing effects from sharpe boundaries
+            // default: no window function via `radWindowFunctionNone`
+
+            /* Choose different window function in order to get better ringing reduction
+             * radWindowFunctionTriangle
+             * radWindowFunctionHamming
+             * radWindowFunctionTriplett
+             * radWindowFunctionGauss
+             * radWindowFunctionNone
+             */
+            namespace radWindowFunctionTriangle
+            {
+            }
+            namespace radWindowFunctionHamming
+            {
+            }
+            namespace radWindowFunctionTriplett
+            {
+            }
+            namespace radWindowFunctionGauss
+            {
+            }
+            namespace radWindowFunctionNone
+            {
+            }
+
+            namespace radWindowFunction = PARAM_RADWINDOWFUNCTION;
+
+        } // namespace radiation
+    } // namespace plugins
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiationObserver.param
@@ -1,0 +1,83 @@
+/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+    namespace plugins
+    {
+        namespace radiation
+        {
+            namespace radiation_observer
+            {
+                /** Compute observation angles
+                 *
+                 * This function is used in the Radiation plug-in kernel to compute
+                 * the observation directions given as a unit vector pointing
+                 * towards a 'virtual' detector
+                 *
+                 * @param    observation_id_extern
+                 *           int index that identifies each block on the GPU
+                 *           to compute the observation direction
+                 *
+                 * @return   unit vector pointing in observation direction
+                 *           type: vector_64
+                 *
+                 */
+                HDINLINE vector_64 observation_direction(const int observation_id_extern)
+                {
+                    /** This computes observation directions for one octant
+                     *  of a sphere around the simulation area.
+                     *  The axises of the octant point towards:
+                     *  (+1,0,0) ; (0,+1,0) ; (0,0,-1)
+                     */
+
+                    /* generate two indices from single block index */
+                    constexpr int N_angle_split = 8; /* index split distance */
+                    /* get column index for computing angle theta: */
+                    const int my_index_theta = observation_id_extern / N_angle_split;
+                    /* get row index for computing angle phi: */
+                    const int my_index_phi = observation_id_extern % N_angle_split;
+
+                    /*  range for BOTH angles */
+                    constexpr picongpu::float_64 angle_range = picongpu::PI / 2.0;
+
+                    /* angle stepwidth for BOTH angles */
+                    constexpr picongpu::float_64 delta_angle_theta = 1.0 * angle_range / (N_angle_split - 1);
+                    constexpr picongpu::float_64 delta_angle_phi = 1.0 * angle_range / (2 - 1);
+                    /* compute both angles */
+                    const picongpu::float_64 theta(my_index_theta * delta_angle_theta);
+                    const picongpu::float_64 phi(my_index_phi * delta_angle_phi);
+
+                    /* compute unit vector */
+                    picongpu::float_32 sinPhi;
+                    picongpu::float_32 cosPhi;
+                    picongpu::float_32 sinTheta;
+                    picongpu::float_32 cosTheta;
+                    pmacc::math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
+                    pmacc::math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+                    return vector_64(sinTheta * cosPhi, sinTheta * sinPhi, cosTheta);
+                }
+
+            } // namespace radiation_observer
+        } // namespace radiation
+    } // namespace plugins
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
@@ -19,6 +19,12 @@
 
 #pragma once
 
+#ifndef PARAM_RADIATION
+/* disable radiation calculation */
+#    define PARAM_RADIATION 0
+#endif
+
+
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/Particles.hpp"
@@ -35,7 +41,13 @@ namespace picongpu
     /*########################### define particle attributes #####################*/
 
     /** describe attributes of a particle */
-    using DefaultParticleAttributes = MakeSeq_t<position<position_pic>, momentum, weighting>;
+    using DefaultParticleAttributes = MakeSeq_t<
+        position<position_pic>,
+        momentum,
+#if(PARAM_RADIATION == 1)
+        momentumPrev1,
+#endif
+        weighting>;
 
     /*########################### end particle attributes ########################*/
 


### PR DESCRIPTION
This is an update to the SPEC benchmark to include various radiation cases. 
Run-time test are still queuing on hemera. 
@psychocoderHPC I am not sure whether `topic-SPEC64Bit` is the correct branch of yours. Its a bit older than the current mainline `dev` but the newest branch I could fin in your profile regarding SPEC benchmarks. 