### PR TITLE
EZ_paper: Update Setup

### DIFF
--- a/share/picongpu/examples/PaperThermal/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/PaperThermal/include/picongpu/param/grid.param
@@ -49,14 +49,14 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        constexpr float_64 DELTA_T_SI = 1.79e-16;
+        constexpr float_64 DELTA_T_SI = 2.80271e-16;
 
         /** equals X
          *  unit: meter */
 
         /** equals X
          *  unit: meter */
-        constexpr float_64 CELL_WIDTH_SI = 9.34635e-8;
+        constexpr float_64 CELL_WIDTH_SI = 1.46260e-07;
         /** equals Y
          *  unit: meter */
         constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;

--- a/share/picongpu/examples/PaperThermal/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/PaperThermal/include/picongpu/param/particle.param
@@ -75,7 +75,7 @@ namespace picongpu
                 /* Initial temperature
                  *  unit: keV
                  */
-                static constexpr float_64 temperature = 10000;
+                static constexpr float_64 temperature = 17.5*510.998950; // most probable E_kin = 10 mc^2
             };
             using AddTemperature = unary::Temperature<TemperatureParam>;
 

--- a/share/picongpu/examples/PaperThermal/include/picongpu/param/species.param
+++ b/share/picongpu/examples/PaperThermal/include/picongpu/param/species.param
@@ -108,6 +108,6 @@ namespace picongpu
      * For development purposes: --------------------------------------------------
      * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
      */
-    using UsedParticlePusher = particles::pusher::Boris;
+    using UsedParticlePusher = particles::pusher::HigueraCary;
 
 } // namespace picongpu


### PR DESCRIPTION
* adjust grid parameters to have
  - a grid spacing applicable for 2D and 3D sims
  - a volume of 5 Debye length per axis
  - 5 times more particles along an axis than Debye length along this axis
* ~~reduce initial temperature to ten times electron rest energy~~
* set initial temperature to yield most probable kinetic energy of ten times rest mass
* switch to correct relativistic pusher