### PR TITLE
Add missing double quotes in handleSlurmSignals

### DIFF
--- a/etc/picongpu/handleSlurmSignals.sh
+++ b/etc/picongpu/handleSlurmSignals.sh
@@ -49,7 +49,7 @@ trap "fireSignal SIGUSR1" SIGUSR1
 trap "fireSignal SIGUSR2" SIGUSR2
 trap "fireSignal SIGUSR1 SIGUSR2" SIGALRM
 
-$@ &
+"$@" &
 APP_PID=$!
 echo "PID = ${APP_PID}"
 


### PR DESCRIPTION
Adds missing double quotes around `$@` in handleSlurmSignals.sh. According to https://unix.stackexchange.com/a/129077 the difference is that the unquoted expression will treat all arguments in the list (following the expression) as unquoted strings, while `'"$@"` puts the arguments in double quotes. The unquoted version `$@` somehow breaks the `picongpu` call if any of the `picongpu` options is  passed as a quoted expression, e.g., when passing a json configuration string for `openPMD`.

Found in an offline discussion with @psychocoderHPC 